### PR TITLE
Polish template.spec

### DIFF
--- a/template/template.spec
+++ b/template/template.spec
@@ -9,7 +9,7 @@ License: CC0
 Summary: Faked provides of %fake_provide}
 
 Provides: %{fake_provides}
-Provides: %{fake_name}
+Provides: fake-%{fake_name}
 BuildArch: noarch
 
 %description

--- a/template/template.spec
+++ b/template/template.spec
@@ -6,7 +6,7 @@ Version: %{fake_version}
 Release: %{fake_release}
 License: CC0
 
-Summary: Faked provides of %fake_provide}
+Summary: Faked provides of %{fake_provides}
 
 Provides: %{fake_provides}
 Provides: fake-%{fake_name}


### PR DESCRIPTION
- `Provides: %{fake_name}` causes trouble if a package is conflicting `%{fake_name}` below a certain version number.
  e.g. Fedora 33 chrony conflicts with `NetworkManager < 1.20` and having fake-NetworkManage package with `Provides: NetworkManager = 1:1.20` set triggers the conflict as "plain" NetworkManager is provides too.
- Fix typo in fake package summary line.