### PR TITLE
Add the ability to require rpms when installing

### DIFF
--- a/create-fake-rpm
+++ b/create-fake-rpm
@@ -5,6 +5,7 @@ VERSION=0
 RELEASE=0
 TARGET="-bs"
 PRINT_RESULT=0
+REQUIRES=""
 
 # parse command line options
 for i in "$@"; do
@@ -19,6 +20,10 @@ for i in "$@"; do
     ;;
     --release=*)
     RELEASE="${i#*=}"
+    shift # past argument
+    ;;
+    --requires=*)
+    REQUIRES+=" ${i#*=}"
     shift # past argument
     ;;
     --build)
@@ -56,6 +61,7 @@ echo "%{!?fake_name: %global fake_name $NAME}" >>${SPECFILE}
 echo "%{!?fake_version: %global fake_version $VERSION}" >>${SPECFILE}
 echo "%{!?fake_release: %global fake_release $RELEASE}" >>${SPECFILE}
 echo "%{!?fake_provides: %global fake_provides $PROVIDES}" >>${SPECFILE}
+echo "%{!?fake_requires: %global fake_requires $REQUIRES}" >>${SPECFILE}
 cat "$TEMPLATEDIR/template.spec" >>${SPECFILE}
 
 OUTPUT=$( rpmbuild \

--- a/create-fake-rpm.1.asciidoc
+++ b/create-fake-rpm.1.asciidoc
@@ -10,7 +10,7 @@ create-fake-rpm - generate fake (S)RPM.
 
 SYNOPSIS
 --------
-*create-fake-rpm* [--help] [--print-result] [--version=VERSION] [--release=RELEASE] [--build] PACKAGE_NAME PROVIDES
+*create-fake-rpm* [--help] [--print-result] [--version=VERSION] [--requires=PACKAGE] [--release=RELEASE] [--build] PACKAGE_NAME PROVIDES
 
 
 DESCRIPTION
@@ -46,6 +46,8 @@ OPTIONS
 --version=VERSION - you can specify version of your package. Default is 0.
 
 --release=RELEASE - you can specify RELEASE of your package. Default is 0.
+
+--requires=PACKAGE - make the resulting rpm require another one, useful for compatibility cases where packages have different names. Can be used multiple times.
 
 --build - create an RPM package. Without this option, only SRC.RPM package will be created.
 

--- a/create-fake-rpm.1.asciidoc
+++ b/create-fake-rpm.1.asciidoc
@@ -10,7 +10,7 @@ create-fake-rpm - generate fake (S)RPM.
 
 SYNOPSIS
 --------
-*create-fake-rpm* [--help] [--print-output] [--version=VERSION] [--release=RELEASE] [--build] PACKAGE_NAME PROVIDES
+*create-fake-rpm* [--help] [--print-result] [--version=VERSION] [--release=RELEASE] [--build] PACKAGE_NAME PROVIDES
 
 
 DESCRIPTION

--- a/template/template.spec
+++ b/template/template.spec
@@ -10,6 +10,9 @@ Summary: Faked provides of %{fake_provides}
 
 Provides: %{fake_provides}
 Provides: %{fake_name}
+%if "%{?fake_requires}" != ""
+Requires: %{fake_requires}
+%endif
 BuildArch: noarch
 
 %description


### PR DESCRIPTION
Allow fake-rpm require different rpms, this is useful mostly for compatibility cases when you need a fake name for a real package. Makes the resulting rpm less dangerous